### PR TITLE
ENG-1713 update to new custom model and switch to UBI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-slim
+FROM registry.access.redhat.com/ubi8/openjdk-8
 ENV PORT 8080
 ENV CLASSPATH /opt/lib
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
 FROM registry.access.redhat.com/ubi8/openjdk-8
+
+### Required OpenShift Labels
+LABEL name="Entando Kubernetes Service" \
+      maintainer="dev@entando.com" \
+      vendor="Entando Inc." \
+      version="6.3.0" \
+      release="6.3.0" \
+      summary="Entando infrastructure project for kubernetest APIs" \
+      description="Entando infrastructure project for kubernetest APIs"
+
+COPY target/generated-resources/licenses /licenses
+
 ENV PORT 8080
 ENV CLASSPATH /opt/lib
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <postDeploymentTestGroups></postDeploymentTestGroups>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.organization>entando-k8s</github.organization>
-        <entando.k8s.custom.model.version>6.2.0</entando.k8s.custom.model.version>
+        <entando.k8s.custom.model.version>6.2.7</entando.k8s.custom.model.version>
         <fabric8.version>4.7.0</fabric8.version>
     </properties>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,19 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <id>download-licenses</id>
+                        <goals>
+                            <goal>download-licenses</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/test/java/org/entando/kubernetes/service/EntandoLinkServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/service/EntandoLinkServiceTest.java
@@ -83,7 +83,7 @@ public class EntandoLinkServiceTest {
         EntandoApp testApp = new EntandoAppBuilder()
                 .withNewMetadata()
                 .withName(testLink.getSpec().getEntandoAppName())
-                .withNamespace(testLink.getSpec().getEntandoAppNamespace())
+                .withNamespace(testLink.getSpec().getEntandoAppNamespace().get())
                 .endMetadata()
                 .build();
         assertEquals(1, linkService.getAppLinks(testApp).size());

--- a/src/test/java/org/entando/kubernetes/service/EntandoLinkServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/service/EntandoLinkServiceTest.java
@@ -108,9 +108,9 @@ public class EntandoLinkServiceTest {
         assertEquals(String.format("%s-to-%s-link", TEST_APP_NAME, TEST_PLUGIN_NAME), createdLink.getMetadata().getName());
         assertEquals(TEST_APP_NAMESPACE, createdLink.getMetadata().getNamespace());
         assertEquals(TEST_APP_NAME, createdLink.getSpec().getEntandoAppName());
-        assertEquals(TEST_APP_NAMESPACE, createdLink.getSpec().getEntandoAppNamespace());
+        assertEquals(TEST_APP_NAMESPACE, createdLink.getSpec().getEntandoAppNamespace().get());
         assertEquals(TEST_PLUGIN_NAME, createdLink.getSpec().getEntandoPluginName());
-        assertEquals(TEST_PLUGIN_NAMESPACE, createdLink.getSpec().getEntandoPluginNamespace());
+        assertEquals(TEST_PLUGIN_NAMESPACE, createdLink.getSpec().getEntandoPluginNamespace().get());
 
         //        assertEquals(1, linkService.listEntandoAppLinks(TEST_APP_NAMESPACE, TEST_APP_NAME).size());
     }
@@ -122,9 +122,9 @@ public class EntandoLinkServiceTest {
 
         EntandoAppPluginLink generatedLink = linkService.buildBetweenAppAndPlugin(ea, ep);
         assertEquals(ea.getMetadata().getName(), generatedLink.getSpec().getEntandoAppName());
-        assertEquals(ea.getMetadata().getNamespace(), generatedLink.getSpec().getEntandoAppNamespace());
+        assertEquals(ea.getMetadata().getNamespace(), generatedLink.getSpec().getEntandoAppNamespace().get());
         assertEquals(ep.getMetadata().getName(), generatedLink.getSpec().getEntandoPluginName());
-        assertEquals(ep.getMetadata().getNamespace(), generatedLink.getSpec().getEntandoPluginNamespace());
+        assertEquals(ep.getMetadata().getNamespace(), generatedLink.getSpec().getEntandoPluginNamespace().get());
 
         assertEquals(ea.getMetadata().getNamespace(), generatedLink.getMetadata().getNamespace());
         assertEquals(

--- a/src/test/java/org/entando/kubernetes/service/EntandoPluginServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/service/EntandoPluginServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.entando.kubernetes.util.EntandoPluginTestHelper.TEST_PLUGIN_NAME;
 import static org.entando.kubernetes.util.EntandoPluginTestHelper.TEST_PLUGIN_NAMESPACE;
 import static org.entando.kubernetes.util.EntandoPluginTestHelper.getTestEntandoPlugin;
-import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,13 +14,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -37,7 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
-import org.springframework.test.web.servlet.ResultActions;
 
 @Tag("component")
 @EnableRuleMigrationSupport
@@ -223,12 +218,12 @@ public class EntandoPluginServiceTest {
         EntandoPlugin actual = availablePlugins.get(0);
         assertEquals(TEST_PLUGIN_NAME, actual.getMetadata().getName());
         assertEquals(expected.getSpec().getImage(), actual.getSpec().getImage());
-        assertEquals(expected.getSpec().getClusterInfrastructureSecretToUse(), actual.getSpec().getClusterInfrastructureSecretToUse());
+        assertEquals(expected.getSpec().getClusterInfrastructureToUse().get(), actual.getSpec().getClusterInfrastructureToUse().get());
         assertEquals(expected.getSpec().getHealthCheckPath(), actual.getSpec().getHealthCheckPath());
         assertEquals(expected.getSpec().getIngressPath(), actual.getSpec().getIngressPath());
-        assertEquals(expected.getSpec().getKeycloakSecretToUse(), actual.getSpec().getKeycloakSecretToUse());
+        assertEquals(expected.getSpec().getKeycloakToUse(), actual.getSpec().getKeycloakToUse());
         assertEquals(expected.getSpec().getConnectionConfigNames(), actual.getSpec().getConnectionConfigNames());
-        assertEquals(expected.getSpec().getParameters(), actual.getSpec().getParameters());
+        assertEquals(expected.getSpec().getEnvironmentVariables(), actual.getSpec().getEnvironmentVariables());
         assertEquals(expected.getSpec().getPermissions(), actual.getSpec().getPermissions());
         assertEquals(expected.getSpec().getRoles(), actual.getSpec().getRoles());
         assertEquals(expected.getSpec().getSecurityLevel(), actual.getSpec().getSecurityLevel());

--- a/src/test/java/org/entando/kubernetes/service/EntandoPluginServiceTest.java
+++ b/src/test/java/org/entando/kubernetes/service/EntandoPluginServiceTest.java
@@ -218,7 +218,6 @@ public class EntandoPluginServiceTest {
         EntandoPlugin actual = availablePlugins.get(0);
         assertEquals(TEST_PLUGIN_NAME, actual.getMetadata().getName());
         assertEquals(expected.getSpec().getImage(), actual.getSpec().getImage());
-        assertEquals(expected.getSpec().getClusterInfrastructureToUse().get(), actual.getSpec().getClusterInfrastructureToUse().get());
         assertEquals(expected.getSpec().getHealthCheckPath(), actual.getSpec().getHealthCheckPath());
         assertEquals(expected.getSpec().getIngressPath(), actual.getSpec().getIngressPath());
         assertEquals(expected.getSpec().getKeycloakToUse(), actual.getSpec().getKeycloakToUse());

--- a/src/test/java/org/entando/kubernetes/util/EntandoAppTestHelper.java
+++ b/src/test/java/org/entando/kubernetes/util/EntandoAppTestHelper.java
@@ -64,7 +64,6 @@ public class EntandoAppTestHelper {
         EntandoApp entandoApp = new EntandoAppBuilder().withNewSpec()
                 .withDbms(DbmsVendor.POSTGRESQL)
                 .withReplicas(1)
-                .withEntandoImageVersion("6.0.0-SNAPSHOT")
                 .withStandardServerImage(JeeServer.WILDFLY)
                 .endSpec()
                 .build();


### PR DESCRIPTION
Smoke tested this on lab.entando.org and pushed an image to my dockerhub

entando-k8s-service: >-
    {"version":"ubi-6.3.0","executable-type":"jvm","registry":"docker.io","organization":"jwhite101"}


Haven't tested ECR yet but thinking better to test holistically once the full set is updated.