### PR TITLE
ENG-2802 undeploy of an EntandoDeBundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-spring-boot-parent</artifactId>
-        <version>6.3.12</version>
+        <version>7.0.0-ENG-2892-PR-8</version>
     </parent>
     <url>http://www.entando.com/</url>
     <licenses>
@@ -51,12 +51,6 @@
         <entando-k8s-custom-model.version>6.3.4</entando-k8s-custom-model.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <!-- START - to remove when pipelines will work again and we will be able to generate an updated parent project -->
-        <fabric8.version>4.13.3</fabric8.version>
-        <spring-boot.version>2.5.6</spring-boot.version>
-        <spring-security-oauth2-autoconfigure.version>2.5.6</spring-security-oauth2-autoconfigure.version>
-        <tomcat-embed.version>9.0.54</tomcat-embed.version>
-        <!-- END - to remove when pipelines will work again and we will be able to generate an updated parent project -->
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.organization>entando-k8s</github.organization>
         <entando-k8s-custom-model.version>6.3.4</entando-k8s-custom-model.version>
-        <fabric8.version>4.10.3</fabric8.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <!-- START - to remove when pipelines will work again and we will be able to generate an updated parent project -->
+        <fabric8.version>4.13.3</fabric8.version>
+        <spring-boot.version>2.5.6</spring-boot.version>
+        <spring-security-oauth2-autoconfigure.version>2.5.6</spring-security-oauth2-autoconfigure.version>
+        <tomcat-embed.version>9.0.54</tomcat-embed.version>
+        <!-- END - to remove when pipelines will work again and we will be able to generate an updated parent project -->
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.entando</groupId>
         <artifactId>entando-spring-boot-parent</artifactId>
-        <version>6.3.10</version>
+        <version>6.3.12</version>
     </parent>
     <url>http://www.entando.com/</url>
     <licenses>

--- a/src/main/java/org/entando/kubernetes/controller/EntandoDeBundleController.java
+++ b/src/main/java/org/entando/kubernetes/controller/EntandoDeBundleController.java
@@ -19,6 +19,7 @@ import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Links;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -70,6 +71,15 @@ public class EntandoDeBundleController {
     @PostMapping(produces = {APPLICATION_JSON_VALUE, HAL_JSON_VALUE})
     public ResponseEntity<EntityModel<EntandoDeBundle>> create(@RequestBody EntandoDeBundle entandoDeBundle) {
         return ResponseEntity.ok(resourceAssembler.toModel(bundleService.createBundle(entandoDeBundle)));
+    }
+
+    @DeleteMapping(path = "/{name}", produces = {APPLICATION_JSON_VALUE, HAL_JSON_VALUE})
+    public ResponseEntity<Void> delete(@PathVariable String name) {
+
+        log.info("Deleting {} EntandoDeBundle", name);
+
+        bundleService.deleteBundle(name);
+        return ResponseEntity.noContent().build();
     }
 
     private CollectionModel<EntityModel<EntandoDeBundle>> getCollectionWithLinks(List<EntandoDeBundle> deBundles) {

--- a/src/main/java/org/entando/kubernetes/exception/BadRequestExceptionFactory.java
+++ b/src/main/java/org/entando/kubernetes/exception/BadRequestExceptionFactory.java
@@ -39,4 +39,8 @@ public final class BadRequestExceptionFactory {
         String message = "Invalid link delete request! appName and pluginName must be not null nor empty - " + req.toString();
         return Problem.valueOf(Status.BAD_REQUEST, message);
     }
+
+    public static ThrowableProblem invalidBundleNameRequest() {
+        return Problem.valueOf(Status.BAD_REQUEST, "Empty bundle name received");
+    }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,5 +1,5 @@
 server.port=8083
 spring.security.oauth2.client.provider.oidc.issuer-uri=http://quickstart-kc-fire.192.168.64.5.nip.io/auth/realms/entando
 spring.security.oauth2.client.registration.oidc.client-id=quickstart-eci-k8s-svc
-spring.security.oauth2.client.registration.oidc.client-secret=af74522a-78c1-425b-baa6-3e1a26c7261a
+spring.security.oauth2.client.registration.oidc.client-secret=6171ed0d-78c8-4236-a1e9-dfb5d26c59b6
 entando.namespaces.to.observe=fire


### PR DESCRIPTION
I also changed the deploy functionality in order to allow the deploy and the undeploy only on these namespaces and respecting the order below:
- caller namespace (identified by the serviceaccount jwt)
- the first observed namespace