### PR TITLE
ENG-5072 add `tenantCode` support when creating a new EntandoAppPluginLink  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- LOCAL OVERRIDES -->
-        <entando-k8s-custom-model.version>7.2.0-ENG-4226-PR-72</entando-k8s-custom-model.version>
+        <entando-k8s-custom-model.version>7.3.0-ENG-5071-PR-81</entando-k8s-custom-model.version>
         <fabric8.version>5.3.2</fabric8.version>
     </properties>
 

--- a/src/main/java/org/entando/kubernetes/service/EntandoLinkService.java
+++ b/src/main/java/org/entando/kubernetes/service/EntandoLinkService.java
@@ -60,16 +60,18 @@ public class EntandoLinkService extends EntandoKubernetesResourceCollector<Entan
     }
 
     public EntandoAppPluginLink deploy(EntandoAppPluginLink newLink) {
-        log.info("Link creation between EntandoApp {} on namespace {} and EntandoPlugin {} on namespace {}",
+        log.info("Link creation between EntandoApp {} on namespace {} and EntandoPlugin {} on namespace {} for tenant {}",
                 newLink.getSpec().getEntandoAppName(), newLink.getSpec().getEntandoAppNamespace(),
-                newLink.getSpec().getEntandoPluginName(), newLink.getSpec().getEntandoPluginNamespace());
+                newLink.getSpec().getEntandoPluginName(), newLink.getSpec().getEntandoPluginNamespace(),
+                newLink.getSpec().getTenantCode());
         return getLinksOperations().inNamespace(newLink.getMetadata().getNamespace()).createOrReplace(newLink);
     }
 
     public void delete(EntandoAppPluginLink l) {
-        log.info("Deleting link between EntandoApp {} on namespace {} and EntandoPlugin {} on namespace {}",
+        log.info("Deleting link between EntandoApp {} on namespace {} and EntandoPlugin {} on namespace {} for tenant {}",
                 l.getSpec().getEntandoAppName(), l.getSpec().getEntandoAppNamespace(),
-                l.getSpec().getEntandoPluginName(), l.getSpec().getEntandoPluginNamespace());
+                l.getSpec().getEntandoPluginName(), l.getSpec().getEntandoPluginNamespace(),
+                l.getSpec().getTenantCode());
         getLinksOperations().inNamespace(l.getMetadata().getNamespace()).delete(l);
     }
 
@@ -78,6 +80,7 @@ public class EntandoLinkService extends EntandoKubernetesResourceCollector<Entan
         String appName = app.getMetadata().getName();
         String pluginName = plugin.getMetadata().getName();
         String pluginNamespace = kubernetesUtils.getDefaultPluginNamespace();
+        String tenantCode = plugin.getSpec().getTenantCode();
         return new EntandoAppPluginLinkBuilder()
                 .withNewMetadata()
                 .withName(createAppPluginLinkName(appName, pluginName))
@@ -86,6 +89,7 @@ public class EntandoLinkService extends EntandoKubernetesResourceCollector<Entan
                 .withNewSpec()
                 .withEntandoApp(appNamespace, appName)
                 .withEntandoPlugin(pluginNamespace, pluginName)
+                .withTenantCode(tenantCode)
                 .endSpec()
                 .build();
     }


### PR DESCRIPTION
Adds the management of the `tenantCode` field when a new EntandoAppPluginLink is requested upon a plugin installation.